### PR TITLE
Update repository name to reflect Zonr Core branding

### DIFF
--- a/README.md
+++ b/README.md
@@ -391,7 +391,7 @@ We welcome contributions! Please see our [Contributing Guide](CONTRIBUTING.md) f
 
 ```bash
 # Clone the repository  
-git clone https://github.com/itsJess1ca/Zonr.git
+git clone https://github.com/itsJess1ca/Zonr-Core.git
 cd zonr
 
 # Install dependencies
@@ -467,15 +467,15 @@ This project is licensed under the MIT License - see the [LICENSE.md](LICENSE.md
 
 ## 📞 Support
 
-- 🐛 **Issues**: [GitHub Issues](https://github.com/itsJess1ca/Zonr/issues)
-- 💬 **Discussions**: [GitHub Discussions](https://github.com/itsJess1ca/Zonr/discussions)
+- 🐛 **Issues**: [GitHub Issues](https://github.com/itsJess1ca/Zonr-Core/issues)
+- 💬 **Discussions**: [GitHub Discussions](https://github.com/itsJess1ca/Zonr-Core/discussions)
 - 📧 **Email**: jessica.ide247@gmail.com
 
 ---
 
 <div align="center">
 
-**[⭐ Give us a star on GitHub!](https://github.com/itsJess1ca/Zonr)**
+**[⭐ Give us a star on GitHub!](https://github.com/itsJess1ca/Zonr-Core)**
 
 Made with ❤️ for the terminal-loving community
 

--- a/package.json
+++ b/package.json
@@ -75,7 +75,7 @@
   "license": "MIT",
   "repository": {
     "type": "git",
-    "url": "https://github.com/itsJess1ca/Zonr.git"
+    "url": "https://github.com/itsJess1ca/Zonr-Core.git"
   },
   "engines": {
     "node": ">=16"


### PR DESCRIPTION
Resolves #4

## Summary
- Renamed GitHub repository from Zonr to Zonr-Core
- Updated package.json repository URL to match new name
- Updated README.md GitHub links (issues, discussions, clone URL)
- Ensures consistency between repository name and package branding

## Changes
- package.json: Updated repository URL
- README.md: Updated all GitHub links to use Zonr-Core
- Repository renamed via GitHub settings

## Benefits
- Better brand alignment with @zonr-logs/core package
- Consistent naming across all documentation
- Improved discoverability and professional appearance

Generated with Claude Code