### PR TITLE
Fix semantic-release workflow blocked by repository protection rules

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,8 +27,8 @@ jobs:
         with:
           # Fetch full history for semantic-release
           fetch-depth: 0
-          # Use a personal access token to allow pushing back to main
-          token: ${{ secrets.GITHUB_TOKEN }}
+          # Use a personal access token to allow pushing back to main and bypass repository rules
+          token: ${{ secrets.RELEASE_PAT || secrets.GITHUB_TOKEN }}
 
       - name: Install pnpm
         uses: pnpm/action-setup@v4
@@ -68,7 +68,7 @@ jobs:
         if: ${{ inputs.dry-run }}
         run: pnpm run release:dry
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.RELEASE_PAT || secrets.GITHUB_TOKEN }}
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
           NPM_CONFIG_USERCONFIG: ~/.npmrc
           HUSKY: 0
@@ -77,7 +77,7 @@ jobs:
         if: ${{ !inputs.dry-run }}
         run: pnpm run release
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.RELEASE_PAT || secrets.GITHUB_TOKEN }}
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
           NPM_CONFIG_USERCONFIG: ~/.npmrc
           HUSKY: 0


### PR DESCRIPTION
Resolves #6

## Summary
- Configure release workflow to use RELEASE_PAT for repository rule bypass
- Update checkout step to use RELEASE_PAT when available 
- Update semantic-release environment variables to use RELEASE_PAT
- Maintain fallback to GITHUB_TOKEN for backward compatibility

## Problem Solved
The semantic-release workflow was failing with repository rule violations because GITHUB_TOKEN cannot bypass branch protection rules. The workflow could not push version bump commits and tags back to the protected main branch.

## Solution
- Use RELEASE_PAT (Personal Access Token) with admin permissions
- Configure workflow to use RELEASE_PAT in all steps that interact with Git
- Enables semantic-release to bypass repository protection rules
- Maintains compatibility for environments without RELEASE_PAT configured

## Testing
Once merged and RELEASE_PAT is configured as a repository secret, the release workflow should successfully:
- Push version bump commits to main branch
- Create and push git tags
- Publish package to npm
- Create GitHub releases

Generated with Claude Code